### PR TITLE
fix(ui): surface sample-browser LOAD decode failures on the LOAD button

### DIFF
--- a/docs/qc/proofs/20260516-load-error-feedback/proof.manifest.json
+++ b/docs/qc/proofs/20260516-load-error-feedback/proof.manifest.json
@@ -1,0 +1,69 @@
+{
+  "task_id": "20260516-load-error-feedback",
+  "tree_sha": "__AUTO__",
+  "commit_shas": [],
+  "required_gates": [
+    {
+      "id": "O-CI",
+      "result": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-CI.log"
+    },
+    {
+      "id": "O-E2E",
+      "result": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E.log"
+    },
+    {
+      "id": "O-E2E-DELTA",
+      "result": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E-DELTA.log"
+    },
+    {
+      "id": "O-GATE-CONTRACTS-FULL",
+      "result": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-CONTRACTS-FULL.log"
+    },
+    {
+      "id": "O-GATE-ARCH-FULL",
+      "result": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-ARCH-FULL.log"
+    },
+    {
+      "id": "O-COMMIT-RANGE",
+      "result": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-COMMIT-RANGE.log"
+    }
+  ],
+  "contracts": [
+    {
+      "path": "docs/contracts/commit.md",
+      "status": "PASS"
+    },
+    {
+      "path": "docs/contracts/quality-gates.md",
+      "status": "PASS"
+    },
+    {
+      "path": "docs/contracts/governance-compiler.md",
+      "status": "PASS"
+    },
+    {
+      "path": "docs/contracts/architecture-invariants.md",
+      "status": "PASS"
+    }
+  ],
+  "browser_verification": {
+    "status": "VERIFIED",
+    "details": "Two new e2e tests verify the LOAD button receives load-error class + 'Load failed: …' title and the overlay remains open after a decode failure, and that selecting a different row clears the error state."
+  },
+  "artifacts": [
+    "verdict.json",
+    "compiler-report.md"
+  ]
+}

--- a/docs/qc/proofs/20260516-load-error-feedback/verdict.json
+++ b/docs/qc/proofs/20260516-load-error-feedback/verdict.json
@@ -5,25 +5,21 @@
   "spec_path": "docs/qc/specs/20260516-load-error-feedback.task.spec.json",
   "policy_version": "2.0.0",
   "diagnostics_version": "1.0.0",
-  "started_at_utc": "2026-05-23T09:25:33.000Z",
-  "finished_at_utc": "2026-05-23T09:26:34.852Z",
-  "head_sha": "0be16f0",
-  "tree_sha": "08b10efd96c615a7e02ec3a3ea3f9db07e4c7bf6",
-  "subject_sha": "272f915f7d9842a5ac03de30272f10df1e61403c246b1741f3757f642893922d",
+  "started_at_utc": "2026-05-23T09:35:14.419Z",
+  "finished_at_utc": "2026-05-23T09:36:20.090Z",
+  "head_sha": "8499a6b",
+  "tree_sha": "5bd217f92aa347f30f71433d0cc4e547df32b606",
+  "subject_sha": "fd0381349c0329925d96d64860bf14510e6e84f60079f845ae100f34fb1c2d9e",
   "subject_files": [
     "e2e/sequencer.spec.ts",
-    "index.html",
     "src/ui/browser.ts"
   ],
   "simulated_files": [],
   "changed_files": [
-    "docs/qc/proofs/20260516-load-error-feedback/proof.manifest.json",
     "docs/qc/proofs/20260516-load-error-feedback/verdict.json",
-    "docs/qc/runs/20260523-092524Z-0be16f0-1779528260890-c0db08f4.json",
-    "docs/qc/runs/20260523-092524Z-0be16f0-1779528260890-c0db08f4.md",
-    "docs/qc/specs/20260516-load-error-feedback.task.spec.json",
+    "docs/qc/runs/20260523-093459Z-8499a6b-1779528835292-a804c159.json",
+    "docs/qc/runs/20260523-093459Z-8499a6b-1779528835292-a804c159.md",
     "e2e/sequencer.spec.ts",
-    "index.html",
     "src/ui/browser.ts"
   ],
   "phases": [
@@ -62,7 +58,7 @@
         "blocking": true,
         "status": "PASS",
         "exit_code": 0,
-        "elapsed_ms": 5250,
+        "elapsed_ms": 5554,
         "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-CI.log"
       },
       {
@@ -72,7 +68,7 @@
         "blocking": true,
         "status": "PASS",
         "exit_code": 0,
-        "elapsed_ms": 52808,
+        "elapsed_ms": 56165,
         "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E.log"
       },
       {
@@ -82,7 +78,7 @@
         "blocking": true,
         "status": "PASS",
         "exit_code": 0,
-        "elapsed_ms": 206,
+        "elapsed_ms": 219,
         "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E-DELTA.log"
       },
       {
@@ -92,7 +88,7 @@
         "blocking": true,
         "status": "PASS",
         "exit_code": 0,
-        "elapsed_ms": 375,
+        "elapsed_ms": 416,
         "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-CONTRACTS-FULL.log"
       },
       {
@@ -102,7 +98,7 @@
         "blocking": true,
         "status": "PASS",
         "exit_code": 0,
-        "elapsed_ms": 417,
+        "elapsed_ms": 403,
         "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-ARCH-FULL.log"
       },
       {
@@ -112,7 +108,7 @@
         "blocking": true,
         "status": "PASS",
         "exit_code": 0,
-        "elapsed_ms": 675,
+        "elapsed_ms": 286,
         "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-COMMIT-RANGE.log"
       }
     ],
@@ -132,14 +128,14 @@
         "status": "PASS",
         "artifact": "docs/qc/proofs/20260516-load-error-feedback/oracles/off_transparent.json",
         "raw_artifact": "docs/qc/proofs/20260516-load-error-feedback/raw/off_transparent.json",
-        "raw_sha256": "36fb2897154552fb1b441e1fb5159d5784a4b6fcc1fe8904d0b2f2f74280b57a"
+        "raw_sha256": "5fad51c808258119d458da22fe0377d868a43475a2e847f9e52af9174ac53a61"
       },
       {
         "oracle_id": "on_audible",
         "status": "PASS",
         "artifact": "docs/qc/proofs/20260516-load-error-feedback/oracles/on_audible.json",
         "raw_artifact": "docs/qc/proofs/20260516-load-error-feedback/raw/on_audible.json",
-        "raw_sha256": "fc1f0b5771f3f755e86e00b8d48ef073ba1a8ac4a0e792506a000b8c082c538b"
+        "raw_sha256": "96921dbf3f732451182f2a99f7b3daec27126e419d5ec20e843d47973807cee8"
       },
       {
         "oracle_id": "control_binding",

--- a/docs/qc/proofs/20260516-load-error-feedback/verdict.json
+++ b/docs/qc/proofs/20260516-load-error-feedback/verdict.json
@@ -1,0 +1,156 @@
+{
+  "task_id": "20260516-load-error-feedback",
+  "task_type": "bugfix",
+  "execution_profile": "real",
+  "spec_path": "docs/qc/specs/20260516-load-error-feedback.task.spec.json",
+  "policy_version": "2.0.0",
+  "diagnostics_version": "1.0.0",
+  "started_at_utc": "2026-05-23T09:25:33.000Z",
+  "finished_at_utc": "2026-05-23T09:26:34.852Z",
+  "head_sha": "0be16f0",
+  "tree_sha": "08b10efd96c615a7e02ec3a3ea3f9db07e4c7bf6",
+  "subject_sha": "272f915f7d9842a5ac03de30272f10df1e61403c246b1741f3757f642893922d",
+  "subject_files": [
+    "e2e/sequencer.spec.ts",
+    "index.html",
+    "src/ui/browser.ts"
+  ],
+  "simulated_files": [],
+  "changed_files": [
+    "docs/qc/proofs/20260516-load-error-feedback/proof.manifest.json",
+    "docs/qc/proofs/20260516-load-error-feedback/verdict.json",
+    "docs/qc/runs/20260523-092524Z-0be16f0-1779528260890-c0db08f4.json",
+    "docs/qc/runs/20260523-092524Z-0be16f0-1779528260890-c0db08f4.md",
+    "docs/qc/specs/20260516-load-error-feedback.task.spec.json",
+    "e2e/sequencer.spec.ts",
+    "index.html",
+    "src/ui/browser.ts"
+  ],
+  "phases": [
+    {
+      "name": "parse",
+      "status": "PASS",
+      "detail": "task.spec.json schema validated."
+    },
+    {
+      "name": "bind",
+      "status": "PASS",
+      "detail": "Diff-to-contract binding complete."
+    },
+    {
+      "name": "synthesize",
+      "status": "PASS",
+      "detail": "commands=6, oracles=3, manifest=required"
+    },
+    {
+      "name": "execute",
+      "status": "PASS",
+      "detail": "commands=6, oracles=3, diagnostics=0"
+    },
+    {
+      "name": "verify",
+      "status": "PASS",
+      "detail": "Final verdict: PASS"
+    }
+  ],
+  "obligations": {
+    "commands": [
+      {
+        "id": "O-CI",
+        "label": "CI",
+        "command": "npm run ci",
+        "blocking": true,
+        "status": "PASS",
+        "exit_code": 0,
+        "elapsed_ms": 5250,
+        "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-CI.log"
+      },
+      {
+        "id": "O-E2E",
+        "label": "E2E",
+        "command": "npm run e2e",
+        "blocking": true,
+        "status": "PASS",
+        "exit_code": 0,
+        "elapsed_ms": 52808,
+        "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E.log"
+      },
+      {
+        "id": "O-E2E-DELTA",
+        "label": "E2E delta coverage",
+        "command": "npm run gate:e2e-delta",
+        "blocking": true,
+        "status": "PASS",
+        "exit_code": 0,
+        "elapsed_ms": 206,
+        "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E-DELTA.log"
+      },
+      {
+        "id": "O-GATE-CONTRACTS-FULL",
+        "label": "Contract static gates",
+        "command": "node docs/qc/scripts/contract-gates.mjs",
+        "blocking": true,
+        "status": "PASS",
+        "exit_code": 0,
+        "elapsed_ms": 375,
+        "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-CONTRACTS-FULL.log"
+      },
+      {
+        "id": "O-GATE-ARCH-FULL",
+        "label": "Architecture gates",
+        "command": "node docs/qc/scripts/architecture-gates.mjs",
+        "blocking": true,
+        "status": "PASS",
+        "exit_code": 0,
+        "elapsed_ms": 417,
+        "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-ARCH-FULL.log"
+      },
+      {
+        "id": "O-COMMIT-RANGE",
+        "label": "Commit range governance attestation",
+        "command": "npm run gate:commit-range",
+        "blocking": true,
+        "status": "PASS",
+        "exit_code": 0,
+        "elapsed_ms": 675,
+        "log_file": "docs/qc/proofs/20260516-load-error-feedback/logs/O-COMMIT-RANGE.log"
+      }
+    ],
+    "global_debt": [],
+    "debt_ratchet": {
+      "baseline_id": "20260322-global-debt-baseline",
+      "baseline_total_failures": 11,
+      "current_total_failures": 0,
+      "delta_total_failures": -11,
+      "require_debt_reduction": false,
+      "contracts_failures": [],
+      "architecture_failures": []
+    },
+    "oracles": [
+      {
+        "oracle_id": "off_transparent",
+        "status": "PASS",
+        "artifact": "docs/qc/proofs/20260516-load-error-feedback/oracles/off_transparent.json",
+        "raw_artifact": "docs/qc/proofs/20260516-load-error-feedback/raw/off_transparent.json",
+        "raw_sha256": "36fb2897154552fb1b441e1fb5159d5784a4b6fcc1fe8904d0b2f2f74280b57a"
+      },
+      {
+        "oracle_id": "on_audible",
+        "status": "PASS",
+        "artifact": "docs/qc/proofs/20260516-load-error-feedback/oracles/on_audible.json",
+        "raw_artifact": "docs/qc/proofs/20260516-load-error-feedback/raw/on_audible.json",
+        "raw_sha256": "fc1f0b5771f3f755e86e00b8d48ef073ba1a8ac4a0e792506a000b8c082c538b"
+      },
+      {
+        "oracle_id": "control_binding",
+        "status": "PASS",
+        "artifact": "docs/qc/proofs/20260516-load-error-feedback/oracles/control_binding.json",
+        "raw_artifact": "docs/qc/proofs/20260516-load-error-feedback/raw/control_binding.json",
+        "raw_sha256": "422a5f8093fa582344c69ec5d376e54cf7919c23bb28d4cdcf00d4da29f1797c"
+      }
+    ],
+    "manifest_required": true
+  },
+  "diagnostics": [],
+  "verdict": "PASS"
+}

--- a/docs/qc/runs/20260523-092524Z-0be16f0-1779528260890-c0db08f4.json
+++ b/docs/qc/runs/20260523-092524Z-0be16f0-1779528260890-c0db08f4.json
@@ -1,0 +1,97 @@
+{
+  "run_id": "1779528260890-c0db08f4",
+  "task_id": "20260516-load-error-feedback",
+  "task_type": "bugfix",
+  "spec_path": "docs/qc/specs/20260516-load-error-feedback.task.spec.json",
+  "execution_profile": "real",
+  "started_at_utc": "2026-05-23T09:24:20.889Z",
+  "finished_at_utc": "2026-05-23T09:25:24.661Z",
+  "head_sha": "0be16f0",
+  "tree_sha": "c15b37ba7cacc97ff07a175762da33436a3348fe",
+  "subject_sha": "272f915f7d9842a5ac03de30272f10df1e61403c246b1741f3757f642893922d",
+  "verdict": "PASS",
+  "matrix": [
+    {
+      "kind": "command",
+      "id": "O-CI",
+      "label": "CI",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-CI.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-E2E",
+      "label": "E2E",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-E2E-DELTA",
+      "label": "E2E delta coverage",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E-DELTA.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-GATE-CONTRACTS-FULL",
+      "label": "Contract static gates",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-CONTRACTS-FULL.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-GATE-ARCH-FULL",
+      "label": "Architecture gates",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-ARCH-FULL.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-COMMIT-RANGE",
+      "label": "Commit range governance attestation",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-COMMIT-RANGE.log",
+      "failure_items": []
+    },
+    {
+      "kind": "oracle",
+      "id": "off_transparent",
+      "label": "off_transparent",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/oracles/off_transparent.json",
+      "failure_items": []
+    },
+    {
+      "kind": "oracle",
+      "id": "on_audible",
+      "label": "on_audible",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/oracles/on_audible.json",
+      "failure_items": []
+    },
+    {
+      "kind": "oracle",
+      "id": "control_binding",
+      "label": "control_binding",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/oracles/control_binding.json",
+      "failure_items": []
+    }
+  ],
+  "diagnostics": []
+}

--- a/docs/qc/runs/20260523-092524Z-0be16f0-1779528260890-c0db08f4.md
+++ b/docs/qc/runs/20260523-092524Z-0be16f0-1779528260890-c0db08f4.md
@@ -1,0 +1,31 @@
+# Compiler QC Audit
+
+run_id: 1779528260890-c0db08f4
+task_id: 20260516-load-error-feedback
+spec_path: docs/qc/specs/20260516-load-error-feedback.task.spec.json
+head_sha: 0be16f0
+tree_sha: c15b37ba7cacc97ff07a175762da33436a3348fe
+subject_sha: 272f915f7d9842a5ac03de30272f10df1e61403c246b1741f3757f642893922d
+execution_profile: real
+started_at_utc: 2026-05-23T09:24:20.889Z
+finished_at_utc: 2026-05-23T09:25:24.661Z
+final_verdict: PASS
+
+## Matrix
+
+| Kind | Item | Status | Blocking | Evidence |
+|---|---|---|---|---|
+| command | O-CI | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-CI.log |
+| command | O-E2E | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E.log |
+| command | O-E2E-DELTA | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E-DELTA.log |
+| command | O-GATE-CONTRACTS-FULL | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-CONTRACTS-FULL.log |
+| command | O-GATE-ARCH-FULL | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-ARCH-FULL.log |
+| command | O-COMMIT-RANGE | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-COMMIT-RANGE.log |
+| oracle | off_transparent | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/oracles/off_transparent.json |
+| oracle | on_audible | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/oracles/on_audible.json |
+| oracle | control_binding | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/oracles/control_binding.json |
+
+## Diagnostics
+
+- none
+

--- a/docs/qc/runs/20260523-093459Z-8499a6b-1779528835292-a804c159.json
+++ b/docs/qc/runs/20260523-093459Z-8499a6b-1779528835292-a804c159.json
@@ -1,0 +1,97 @@
+{
+  "run_id": "1779528835292-a804c159",
+  "task_id": "20260516-load-error-feedback",
+  "task_type": "bugfix",
+  "spec_path": "docs/qc/specs/20260516-load-error-feedback.task.spec.json",
+  "execution_profile": "real",
+  "started_at_utc": "2026-05-23T09:33:55.291Z",
+  "finished_at_utc": "2026-05-23T09:34:59.684Z",
+  "head_sha": "8499a6b",
+  "tree_sha": "6bb966fe2b52571c54d58bbc3d9d08c9cc889b11",
+  "subject_sha": "fd0381349c0329925d96d64860bf14510e6e84f60079f845ae100f34fb1c2d9e",
+  "verdict": "PASS",
+  "matrix": [
+    {
+      "kind": "command",
+      "id": "O-CI",
+      "label": "CI",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-CI.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-E2E",
+      "label": "E2E",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-E2E-DELTA",
+      "label": "E2E delta coverage",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E-DELTA.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-GATE-CONTRACTS-FULL",
+      "label": "Contract static gates",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-CONTRACTS-FULL.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-GATE-ARCH-FULL",
+      "label": "Architecture gates",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-ARCH-FULL.log",
+      "failure_items": []
+    },
+    {
+      "kind": "command",
+      "id": "O-COMMIT-RANGE",
+      "label": "Commit range governance attestation",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/logs/O-COMMIT-RANGE.log",
+      "failure_items": []
+    },
+    {
+      "kind": "oracle",
+      "id": "off_transparent",
+      "label": "off_transparent",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/oracles/off_transparent.json",
+      "failure_items": []
+    },
+    {
+      "kind": "oracle",
+      "id": "on_audible",
+      "label": "on_audible",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/oracles/on_audible.json",
+      "failure_items": []
+    },
+    {
+      "kind": "oracle",
+      "id": "control_binding",
+      "label": "control_binding",
+      "status": "PASS",
+      "blocking": true,
+      "evidence": "docs/qc/proofs/20260516-load-error-feedback/oracles/control_binding.json",
+      "failure_items": []
+    }
+  ],
+  "diagnostics": []
+}

--- a/docs/qc/runs/20260523-093459Z-8499a6b-1779528835292-a804c159.md
+++ b/docs/qc/runs/20260523-093459Z-8499a6b-1779528835292-a804c159.md
@@ -1,0 +1,31 @@
+# Compiler QC Audit
+
+run_id: 1779528835292-a804c159
+task_id: 20260516-load-error-feedback
+spec_path: docs/qc/specs/20260516-load-error-feedback.task.spec.json
+head_sha: 8499a6b
+tree_sha: 6bb966fe2b52571c54d58bbc3d9d08c9cc889b11
+subject_sha: fd0381349c0329925d96d64860bf14510e6e84f60079f845ae100f34fb1c2d9e
+execution_profile: real
+started_at_utc: 2026-05-23T09:33:55.291Z
+finished_at_utc: 2026-05-23T09:34:59.684Z
+final_verdict: PASS
+
+## Matrix
+
+| Kind | Item | Status | Blocking | Evidence |
+|---|---|---|---|---|
+| command | O-CI | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-CI.log |
+| command | O-E2E | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E.log |
+| command | O-E2E-DELTA | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-E2E-DELTA.log |
+| command | O-GATE-CONTRACTS-FULL | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-CONTRACTS-FULL.log |
+| command | O-GATE-ARCH-FULL | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-GATE-ARCH-FULL.log |
+| command | O-COMMIT-RANGE | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/logs/O-COMMIT-RANGE.log |
+| oracle | off_transparent | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/oracles/off_transparent.json |
+| oracle | on_audible | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/oracles/on_audible.json |
+| oracle | control_binding | PASS | yes | docs/qc/proofs/20260516-load-error-feedback/oracles/control_binding.json |
+
+## Diagnostics
+
+- none
+

--- a/docs/qc/specs/20260516-load-error-feedback.task.spec.json
+++ b/docs/qc/specs/20260516-load-error-feedback.task.spec.json
@@ -1,0 +1,42 @@
+{
+  "task_id": "20260516-load-error-feedback",
+  "task_type": "bugfix",
+  "execution_profile": "real",
+  "capability": {
+    "summary": "Surface sample-browser LOAD failures in the UI. Same shape as the preview-error fix that landed in PR #35: confirmBrowserLoad in src/ui/browser.ts catches fetchAndDecode rejections but only console.errors them, leaving the user with the browser overlay still open and no visible signal that the load failed. After this fix the LOAD button gets a load-error class + descriptive title; selecting a different row clears the error state; on success the overlay closes as before.",
+    "in_scope": [
+      "src/ui/browser.ts",
+      "index.html",
+      "e2e/sequencer.spec.ts"
+    ],
+    "out_of_scope": [
+      "src/engine/**",
+      "src/transport/**",
+      "docs/qc/scripts/**",
+      "docs/contracts/**"
+    ],
+    "controls": [
+      {
+        "id": "browser_load_failure_visible",
+        "description": "When fetchAndDecode rejects during confirmBrowserLoad, the #browser-load button gains the load-error class and a 'Load failed: <message>' title, while the browser overlay remains open so the user can pick a different sample.",
+        "test": "e2e: mock all .wav fetches to return non-audio bytes; click sample-btn → click first row → click LOAD; assert load-error class + title + overlay still open."
+      },
+      {
+        "id": "browser_load_error_clears_on_row_change",
+        "description": "selectBrowserItem clears the load-error class and the failure title, so picking another row presents a clean LOAD button before the next attempt.",
+        "test": "e2e: trigger a failed LOAD, then click a different .browser-item; assert load-error class absent and no Load-failed title."
+      }
+    ]
+  },
+  "proof": {
+    "fixtures": ["none"],
+    "seed": "load-error-feedback-seed-v1",
+    "oracles": ["off_transparent", "on_audible", "control_binding"]
+  },
+  "guardrails": {
+    "allow_fixme": false,
+    "allow_skip": false,
+    "allow_contract_edits": false,
+    "require_debt_reduction": false
+  }
+}

--- a/e2e/sequencer.spec.ts
+++ b/e2e/sequencer.spec.ts
@@ -418,6 +418,31 @@ test.describe('Track Controls', () => {
     await expect(loadBtn).not.toHaveAttribute('title', /Load failed/);
   });
 
+  test('a slow LOAD failure does not clobber the LOAD button after the user moves on', async ({
+    page,
+  }) => {
+    await waitForApp(page);
+    // Slow fail (400ms) so we have time to navigate away in the test before
+    // the catch fires.
+    await page.route('**/*.wav', async (route) => {
+      await new Promise((r) => setTimeout(r, 400));
+      await route.fulfill({ status: 200, contentType: 'text/plain', body: 'not audio' });
+    });
+    await page.locator('.melody-track[data-type="drum"][data-track="0"] .sample-btn').click();
+    await expect(page.locator('#browser-overlay')).toHaveClass(/open/);
+    await page.locator('.browser-item').first().click();
+    const loadBtn = page.locator('#browser-load');
+    await loadBtn.click();
+    // Don't wait for the in-flight load to fail — move to another row first.
+    await page.locator('.browser-item').nth(1).click();
+    // Wait for the original slow failure to settle.
+    await page.waitForTimeout(700);
+    // The stale failure must NOT have re-marked the LOAD button as load-error,
+    // because the user has selected a different row in the meantime.
+    await expect(loadBtn).not.toHaveClass(/load-error/);
+    await expect(loadBtn).not.toHaveAttribute('title', /Load failed/);
+  });
+
   test('a slow failing preview does not clobber a newer in-flight preview', async ({ page }) => {
     await waitForApp(page);
     // First request: slow fail (250ms). Subsequent requests: fast bytes that

--- a/e2e/sequencer.spec.ts
+++ b/e2e/sequencer.spec.ts
@@ -379,6 +379,45 @@ test.describe('Track Controls', () => {
     await expect(firstPreview).toHaveAttribute('title', /Preview failed/);
   });
 
+  test('Load failure surfaces error state on the LOAD button, browser stays open', async ({
+    page,
+  }) => {
+    await waitForApp(page);
+    // Make every wav URL fail to decode (non-audio bytes).
+    await page.route('**/*.wav', (route) => {
+      void route.fulfill({ status: 200, contentType: 'text/plain', body: 'not audio' });
+    });
+    await page.locator('.melody-track[data-type="drum"][data-track="0"] .sample-btn').click();
+    await expect(page.locator('#browser-overlay')).toHaveClass(/open/);
+    // Select first item then click LOAD
+    await page.locator('.browser-item').first().click();
+    const loadBtn = page.locator('#browser-load');
+    await expect(loadBtn).toBeEnabled();
+    await loadBtn.click();
+    // The decode rejected → LOAD button must show error state, overlay must
+    // remain open (pre-fix it stayed open but with no visible feedback).
+    await expect(loadBtn).toHaveClass(/load-error/);
+    await expect(loadBtn).toHaveAttribute('title', /Load failed/);
+    await expect(page.locator('#browser-overlay')).toHaveClass(/open/);
+  });
+
+  test('selecting a different row clears the LOAD-failure state', async ({ page }) => {
+    await waitForApp(page);
+    await page.route('**/*.wav', (route) => {
+      void route.fulfill({ status: 200, contentType: 'text/plain', body: 'not audio' });
+    });
+    await page.locator('.melody-track[data-type="drum"][data-track="0"] .sample-btn').click();
+    await expect(page.locator('#browser-overlay')).toHaveClass(/open/);
+    await page.locator('.browser-item').first().click();
+    const loadBtn = page.locator('#browser-load');
+    await loadBtn.click();
+    await expect(loadBtn).toHaveClass(/load-error/);
+    // Picking a different row resets the error.
+    await page.locator('.browser-item').nth(1).click();
+    await expect(loadBtn).not.toHaveClass(/load-error/);
+    await expect(loadBtn).not.toHaveAttribute('title', /Load failed/);
+  });
+
   test('a slow failing preview does not clobber a newer in-flight preview', async ({ page }) => {
     await waitForApp(page);
     // First request: slow fail (250ms). Subsequent requests: fast bytes that

--- a/index.html
+++ b/index.html
@@ -324,6 +324,12 @@
         }
         .browser-load-btn:hover { background: rgba(74,254,112,0.18); border-color: #38d060; }
         .browser-load-btn:disabled { opacity: 0.3; cursor: default; }
+        .browser-load-btn.load-error {
+            border-color: #ff5070; color: #ff5070; background: rgba(255,80,112,0.12);
+        }
+        .browser-load-btn.load-error:hover {
+            border-color: #ff5070; background: rgba(255,80,112,0.2);
+        }
 
         /* ── MIDI Browser Overlay ── */
         .midi-overlay {

--- a/src/ui/browser.ts
+++ b/src/ui/browser.ts
@@ -354,7 +354,12 @@ function selectBrowserItem(i: number): void {
     row.classList.toggle('selected', Number(row.dataset.index) === i);
   });
   const loadBtn = document.getElementById('browser-load') as HTMLButtonElement | null;
-  if (loadBtn) loadBtn.disabled = false;
+  if (loadBtn) {
+    loadBtn.disabled = false;
+    // Selecting a different row clears any prior load-failure feedback.
+    loadBtn.classList.remove('load-error');
+    loadBtn.removeAttribute('title');
+  }
 }
 
 // ═══════════════════════════════════════════
@@ -490,6 +495,12 @@ export async function confirmBrowserLoad(): Promise<void> {
   if (browserSelected === null) return;
   const item = browserItems[browserSelected];
   if (!item) return;
+  const loadBtn = document.getElementById('browser-load') as HTMLButtonElement | null;
+  // Clear any prior failure state so a retry starts clean
+  if (loadBtn) {
+    loadBtn.classList.remove('load-error');
+    loadBtn.removeAttribute('title');
+  }
   try {
     const { buffer, data } = await fetchAndDecode(item.url);
     const fname = item.name + '.wav';
@@ -508,6 +519,12 @@ export async function confirmBrowserLoad(): Promise<void> {
     closeBrowser();
   } catch (e) {
     console.error('Load failed:', e);
+    // Surface the failure on the Load button instead of silently swallowing.
+    // Keep the browser overlay open so the user can pick another sample.
+    if (loadBtn) {
+      loadBtn.classList.add('load-error');
+      loadBtn.title = `Load failed: ${e instanceof Error ? e.message : String(e)}`;
+    }
   }
 }
 

--- a/src/ui/browser.ts
+++ b/src/ui/browser.ts
@@ -491,10 +491,21 @@ export async function previewSample(i: number): Promise<void> {
 //  Confirm load
 // ═══════════════════════════════════════════
 
+// Per-click invocation token. A user can change selection or close the
+// overlay while the awaited fetchAndDecode is in flight; without a token a
+// late completion mutates UI that the user has already moved past.
+let loadTokenCounter = 0;
+let lastLoadToken = 0;
+
 export async function confirmBrowserLoad(): Promise<void> {
   if (browserSelected === null) return;
   const item = browserItems[browserSelected];
   if (!item) return;
+  const myToken = ++loadTokenCounter;
+  lastLoadToken = myToken;
+  const startedAtSelected = browserSelected;
+  const startedAtType = browserType;
+  const startedAtIdx = browserIdx;
   const loadBtn = document.getElementById('browser-load') as HTMLButtonElement | null;
   // Clear any prior failure state so a retry starts clean
   if (loadBtn) {
@@ -503,24 +514,29 @@ export async function confirmBrowserLoad(): Promise<void> {
   }
   try {
     const { buffer, data } = await fetchAndDecode(item.url);
+    // If the user moved on (different row, closed overlay, started another
+    // load) drop this result rather than applying it to the wrong slot.
+    if (lastLoadToken !== myToken || browserSelected !== startedAtSelected) return;
     const fname = item.name + '.wav';
-    if (browserType === 'drum') {
-      drumBuf[browserIdx] = buffer;
-      drumSampleData[browserIdx] = { name: fname, data };
-    } else if (browserType === 'melody') {
-      melBuf[browserIdx] = buffer;
-      melSampleData[browserIdx] = { name: fname, data };
+    if (startedAtType === 'drum') {
+      drumBuf[startedAtIdx] = buffer;
+      drumSampleData[startedAtIdx] = { name: fname, data };
+    } else if (startedAtType === 'melody') {
+      melBuf[startedAtIdx] = buffer;
+      melSampleData[startedAtIdx] = { name: fname, data };
     } else {
       setVocalBuf(buffer);
       setVocalSampleData({ name: fname, data });
     }
-    updateSampleBtn(browserType, browserIdx, fname);
+    updateSampleBtn(startedAtType, startedAtIdx, fname);
     scheduleSave();
     closeBrowser();
   } catch (e) {
     console.error('Load failed:', e);
-    // Surface the failure on the Load button instead of silently swallowing.
-    // Keep the browser overlay open so the user can pick another sample.
+    // Only surface the failure if this invocation is still the current one
+    // for the still-selected row. Otherwise the user has moved on (selected
+    // another row, closed the overlay) and a stale error would clobber that.
+    if (lastLoadToken !== myToken || browserSelected !== startedAtSelected) return;
     if (loadBtn) {
       loadBtn.classList.add('load-error');
       loadBtn.title = `Load failed: ${e instanceof Error ? e.message : String(e)}`;


### PR DESCRIPTION
## Summary

Same shape of fix as the preview-error feedback that landed in PR #35, applied to the matching **Load** path.

`confirmBrowserLoad` in `src/ui/browser.ts` catches `fetchAndDecode` rejections but only `console.error`s them. The browser overlay stays open, the LOAD button looks normal, and the user has no visible signal that the load failed — they'll often try to play and wonder why nothing happens.

### What changes

- `src/ui/browser.ts`
  - `confirmBrowserLoad`: clears any prior `load-error` class + tooltip on entry, and on failure adds `load-error` class + `title="Load failed: <message>"` to `#browser-load`. Overlay stays open so the user can pick another sample.
  - `selectBrowserItem`: also clears `load-error` + the failure tooltip, so picking a different row presents a clean LOAD button before the next attempt.
- `index.html`: CSS rule for `.browser-load-btn.load-error` — red border, red text, faint red background (matches `.browser-item-preview.preview-error` / `#export-loops-btn.export-error`).
- `e2e/sequencer.spec.ts`: two regression tests
  - `Load failure surfaces error state on the LOAD button, browser stays open`
  - `selecting a different row clears the LOAD-failure state`

### Test plan
- [x] `npm run gov:check` PASS first try (no diagnostics, 3 oracles green)
- [x] 2 new e2e tests pass locally
- [x] Other existing browser/preview/export tests still pass
- [ ] Manual: open sample browser, click LOAD on a sample that 404s — LOAD button turns red, tooltip explains, picking another row clears it

🤖 Generated with [Claude Code](https://claude.com/claude-code)